### PR TITLE
Remove saver and rune pool

### DIFF
--- a/src/pages/positions/index.tsx
+++ b/src/pages/positions/index.tsx
@@ -84,8 +84,8 @@ const Component: FC = () => {
 
         <PositionItem
           data={rujiraStake}
-          text="No RUJIRA Stake Position Found"
-          title="RUJIRA Stake"
+          text="No Staked RUJI Position Found"
+          title="Staked RUJI"
         />
 
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed Rune Pool and Saver sections from the Positions page; those positions are no longer shown.
  * Updated RUJIRA Stake display to "Staked RUJI" with corresponding empty-state text "No Staked RUJI Position Found".
  * Liquidity Position, Bond, TCY Stake, and Maya positions remain available and unchanged.
  * No impact to account data, navigation, performance, public APIs, or integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->