### PR TITLE
Update download link in achievements page

### DIFF
--- a/src/pages/achievements/index.tsx
+++ b/src/pages/achievements/index.tsx
@@ -334,7 +334,7 @@ const Component: FC = () => {
         <div className="boost">
           <p>{t(constantKeys.BOOST_YOUR_EAENINGS)}</p>
           <div className="plans">
-            <a href="https://vultisig.com/download/vultisig" target="_blank">
+            <a href="https://vultisig.com/downloads" target="_blank">
               <div className="item">
                 <img src="/images/refresh.svg" />
                 <div className="info">


### PR DESCRIPTION
Changed the download link in the achievements page from 'https://vultisig.com/download/vultisig' to 'https://vultisig.com/downloads' to ensure users are directed to the correct downloads page.