### PR TITLE
Announce airdrop discontinuation across all pages

### DIFF
--- a/src/components/airdrop-banner/index.tsx
+++ b/src/components/airdrop-banner/index.tsx
@@ -5,13 +5,17 @@ const AirdropBanner: FC = () => {
   return (
     <Alert
       message={
-        <span>
+        <span style={{ fontSize: "16px", fontWeight: 500 }}>
           Airdrop is discontinued.{" "}
           <a
             href="https://x.com/vultisig/status/2006823008854298799"
             target="_blank"
             rel="noopener noreferrer"
-            style={{ color: "#33e6bf", textDecoration: "underline" }}
+            style={{
+              color: "#33e6bf",
+              textDecoration: "underline",
+              fontWeight: 600,
+            }}
           >
             Read details here
           </a>
@@ -25,9 +29,12 @@ const AirdropBanner: FC = () => {
         borderRadius: 0,
         borderLeft: 0,
         borderRight: 0,
-        backgroundColor: "rgba(51, 230, 191, 0.1)",
-        borderColor: "rgba(51, 230, 191, 0.3)",
+        backgroundColor: "rgba(51, 230, 191, 0.15)",
+        borderColor: "rgba(51, 230, 191, 0.4)",
+        borderBottom: "2px solid rgba(51, 230, 191, 0.4)",
         color: "#fff",
+        padding: "16px 24px",
+        minHeight: "56px",
       }}
     />
   );

--- a/src/components/airdrop-banner/index.tsx
+++ b/src/components/airdrop-banner/index.tsx
@@ -6,7 +6,7 @@ const AirdropBanner: FC = () => {
     <Alert
       message={
         <span style={{ fontSize: "16px", fontWeight: 500 }}>
-          Airdrop is discontinued.{" "}
+          ⚠️ Airdrop Program Discontinued -{" "}
           <a
             href="https://x.com/vultisig/status/2006823008854298799"
             target="_blank"
@@ -17,7 +17,7 @@ const AirdropBanner: FC = () => {
               fontWeight: 600,
             }}
           >
-            Read details here
+            View official announcement
           </a>
         </span>
       }

--- a/src/components/airdrop-banner/index.tsx
+++ b/src/components/airdrop-banner/index.tsx
@@ -1,0 +1,36 @@
+import { FC } from "react";
+import { Alert } from "antd";
+
+const AirdropBanner: FC = () => {
+  return (
+    <Alert
+      message={
+        <span>
+          Airdrop is discontinued.{" "}
+          <a
+            href="https://x.com/vultisig/status/2006823008854298799"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "#33e6bf", textDecoration: "underline" }}
+          >
+            Read details here
+          </a>
+        </span>
+      }
+      type="info"
+      banner
+      closable={false}
+      style={{
+        textAlign: "center",
+        borderRadius: 0,
+        borderLeft: 0,
+        borderRight: 0,
+        backgroundColor: "rgba(51, 230, 191, 0.1)",
+        borderColor: "rgba(51, 230, 191, 0.3)",
+        color: "#fff",
+      }}
+    />
+  );
+};
+
+export default AirdropBanner;

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -57,7 +57,7 @@ interface InitialState {
   visible: boolean;
 }
 
-const Component: FC<ComponentProps> = ({ updateVault, layout, vault }) => {
+const Component: FC<ComponentProps> = ({  layout, vault }) => {
   const { t } = useTranslation();
   const initialState: InitialState = { visible: false };
   const [state, setState] = useState(initialState);

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -46,6 +46,7 @@ import {
   Storage,
   Vultisig,
 } from "icons";
+import AirdropBanner from "components/airdrop-banner";
 
 interface ComponentProps {
   updateVault?: (vault: VaultProps) => void;
@@ -542,6 +543,7 @@ const Component: FC<ComponentProps> = ({ updateVault, layout, vault }) => {
 
   return (
     <>
+      <AirdropBanner />
       <div className="layout-header">
         {isDesktop ? (
           <Dropdown menu={{ items: dropdownMenu }} className="menu">

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from "react";
-import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+import { Link, useLocation, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useMediaQuery } from "react-responsive";
 import {
@@ -24,7 +24,6 @@ import {
 } from "utils/functions";
 import { VaultProps } from "utils/interfaces";
 import { getStoredVaults } from "utils/storage";
-import api from "utils/api";
 import useGoBack from "hooks/go-back";
 import i18n from "i18n/config";
 import constantKeys from "i18n/constant-keys";
@@ -55,43 +54,42 @@ interface ComponentProps {
 }
 
 interface InitialState {
-  loading: boolean;
   visible: boolean;
 }
 
 const Component: FC<ComponentProps> = ({ updateVault, layout, vault }) => {
   const { t } = useTranslation();
-  const initialState: InitialState = { loading: false, visible: false };
+  const initialState: InitialState = { visible: false };
   const [state, setState] = useState(initialState);
-  const { loading, visible } = state;
+  const { visible } = state;
   const { activePage, baseValue, currency, seasonInfo } = useBaseContext();
   const [messageApi, contextHolder] = message.useMessage();
-  const { pathname, hash } = useLocation();
+  const { hash } = useLocation();
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const goBack = useGoBack();
   const vaults = getStoredVaults();
 
-  const handleJoinAirdrop = () => {
-    if (vault && !loading) {
-      setState((prevState) => ({ ...prevState, loading: true }));
+  // Airdrop discontinued - function disabled
+  // const handleJoinAirdrop = () => {
+  //   if (vault && !loading) {
+  //     setState((prevState) => ({ ...prevState, loading: true }));
 
-      api.airdrop
-        .join(vault)
-        .then(() => {
-          if (updateVault) updateVault({ ...vault, joinAirdrop: true });
+  //     api.airdrop
+  //       .join(vault)
+  //       .then(() => {
+  //         if (updateVault) updateVault({ ...vault, joinAirdrop: true });
 
-          setState((prevState) => ({ ...prevState, loading: false }));
+  //         setState((prevState) => ({ ...prevState, loading: false }));
 
-          navigate(`${pathname}#${constantModals.JOIN_AIRDROP}`, {
-            replace: true,
-          });
-        })
-        .catch(() => {
-          setState((prevState) => ({ ...prevState, loading: false }));
-        });
-    }
-  };
+  //         navigate(`${pathname}#${constantModals.JOIN_AIRDROP}`, {
+  //           replace: true,
+  //         });
+  //       })
+  //       .catch(() => {
+  //         setState((prevState) => ({ ...prevState, loading: false }));
+  //       });
+  //   }
+  // };
 
   const handleSharePath = (path: string): string => {
     return path
@@ -557,7 +555,8 @@ const Component: FC<ComponentProps> = ({ updateVault, layout, vault }) => {
           </Button>
         )}
         {/* <Button href={`#${constantModals.SHARE_ACHIEVEMENTS}`}>"Share"</Button> */}
-        {layout === LayoutKey.VAULT && !vault?.joinAirdrop && (
+        {/* Join Airdrop button disabled - airdrop discontinued */}
+        {/* {layout === LayoutKey.VAULT && !vault?.joinAirdrop && (
           <Button
             onClick={handleJoinAirdrop}
             loading={isDesktop && loading}
@@ -565,7 +564,7 @@ const Component: FC<ComponentProps> = ({ updateVault, layout, vault }) => {
           >
             {t(constantKeys.JOIN_AIRDROP)}
           </Button>
-        )}
+        )} */}
 
         <Link
           to={


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an airdrop discontinuation banner with a link to the official announcement, shown in the header and mobile drawer.
* **Chores**
  * The airdrop join action has been disabled (the UI may remain visible but cannot be used).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->